### PR TITLE
Restructure ecs

### DIFF
--- a/star-dash/star-dash.xcodeproj/project.pbxproj
+++ b/star-dash/star-dash.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 		14E247952BA2CB480071FFC0 /* EventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E247942BA2CB480071FFC0 /* EventManager.swift */; };
 		4604BBD52BA819C70078B84C /* InventoryComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4604BBD42BA819C70078B84C /* InventoryComponent.swift */; };
 		4604BBD92BA81C940078B84C /* InventorySystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4604BBD82BA81C940078B84C /* InventorySystem.swift */; };
+		460A20092BB1B524002597B8 /* EventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460A20082BB1B524002597B8 /* EventListener.swift */; };
+		460A200B2BB1D04F002597B8 /* AttackSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460A200A2BB1D04F002597B8 /* AttackSystem.swift */; };
+		460A200D2BB1DF27002597B8 /* PlayerSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460A200C2BB1DF27002597B8 /* PlayerSystem.swift */; };
+		460A200F2BB1E1F1002597B8 /* CollisionSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460A200E2BB1E1F1002597B8 /* CollisionSystem.swift */; };
+		460A20112BB1E6DF002597B8 /* MonsterSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460A20102BB1E6DF002597B8 /* MonsterSystem.swift */; };
 		461148912BA1CDBF0073E7E1 /* SystemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461148902BA1CDBF0073E7E1 /* SystemManager.swift */; };
 		461148932BA1D04B0073E7E1 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461148922BA1D04B0073E7E1 /* System.swift */; };
 		461148962BA1D53D0073E7E1 /* PositionSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461148952BA1D53D0073E7E1 /* PositionSystem.swift */; };
@@ -171,6 +176,11 @@
 		14E247942BA2CB480071FFC0 /* EventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventManager.swift; sourceTree = "<group>"; };
 		4604BBD42BA819C70078B84C /* InventoryComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryComponent.swift; sourceTree = "<group>"; };
 		4604BBD82BA81C940078B84C /* InventorySystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventorySystem.swift; sourceTree = "<group>"; };
+		460A20082BB1B524002597B8 /* EventListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventListener.swift; sourceTree = "<group>"; };
+		460A200A2BB1D04F002597B8 /* AttackSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttackSystem.swift; sourceTree = "<group>"; };
+		460A200C2BB1DF27002597B8 /* PlayerSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSystem.swift; sourceTree = "<group>"; };
+		460A200E2BB1E1F1002597B8 /* CollisionSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollisionSystem.swift; sourceTree = "<group>"; };
+		460A20102BB1E6DF002597B8 /* MonsterSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonsterSystem.swift; sourceTree = "<group>"; };
 		461148902BA1CDBF0073E7E1 /* SystemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemManager.swift; sourceTree = "<group>"; };
 		461148922BA1D04B0073E7E1 /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		461148952BA1D53D0073E7E1 /* PositionSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSystem.swift; sourceTree = "<group>"; };
@@ -301,6 +311,7 @@
 				145F2C7F2BA203B400457549 /* Event.swift */,
 				14E247942BA2CB480071FFC0 /* EventManager.swift */,
 				145F2C832BA22CA300457549 /* EventModifiable.swift */,
+				460A20082BB1B524002597B8 /* EventListener.swift */,
 				1471B0AB2BA6AE4400878B14 /* ToolEvents */,
 				14D14B742BA5A72800386C3B /* PlayerEvents */,
 				14D14B782BA5ABAC00386C3B /* MonsterEvents */,
@@ -369,6 +380,10 @@
 				461148952BA1D53D0073E7E1 /* PositionSystem.swift */,
 				461148972BA1E41F0073E7E1 /* PhysicsSystem.swift */,
 				4604BBD82BA81C940078B84C /* InventorySystem.swift */,
+				460A200A2BB1D04F002597B8 /* AttackSystem.swift */,
+				460A200C2BB1DF27002597B8 /* PlayerSystem.swift */,
+				460A200E2BB1E1F1002597B8 /* CollisionSystem.swift */,
+				460A20102BB1E6DF002597B8 /* MonsterSystem.swift */,
 			);
 			path = Systems;
 			sourceTree = "<group>";
@@ -829,6 +844,7 @@
 				4E59E2682BADA7B6007B3FA7 /* CollectibleEntityPersistable.swift in Sources */,
 				46D418162BA5CBD60091A38B /* Collidable.swift in Sources */,
 				461148912BA1CDBF0073E7E1 /* SystemManager.swift in Sources */,
+				460A20112BB1E6DF002597B8 /* MonsterSystem.swift in Sources */,
 				4E59E2512BAB2EAE007B3FA7 /* StorageManager.swift in Sources */,
 				145F2C842BA22CA300457549 /* EventModifiable.swift in Sources */,
 				4E630EFA2B9F7E070008F887 /* ViewController.swift in Sources */,
@@ -862,10 +878,13 @@
 				46D418242BA5D5280091A38B /* Tool+Collidable.swift in Sources */,
 				E64361142BA4C2CD003850FD /* CreationModule.swift in Sources */,
 				4E59E2612BAB42FD007B3FA7 /* LevelPersistable.swift in Sources */,
+				460A200B2BB1D04F002597B8 /* AttackSystem.swift in Sources */,
 				E6A745162BA057040080C1BE /* MTKRenderer.swift in Sources */,
 				E6A745182BA057040080C1BE /* Renderer.swift in Sources */,
 				4E59E25F2BAB4134007B3FA7 /* EntityType.swift in Sources */,
+				460A200D2BB1DF27002597B8 /* PlayerSystem.swift in Sources */,
 				E6A745172BA057040080C1BE /* ControlView.swift in Sources */,
+				460A20092BB1B524002597B8 /* EventListener.swift in Sources */,
 				14970F562BA8177B00CC1E8A /* GameConstants.swift in Sources */,
 				1471B0A42BA6AAF200878B14 /* PlayerDeathEvent.swift in Sources */,
 				E69FDDE62BADD11B0089D5F3 /* StopMovingEvent.swift in Sources */,
@@ -888,6 +907,7 @@
 				4E86605C2BA095460035530D /* Monster.swift in Sources */,
 				4E59E2632BACB9E2007B3FA7 /* LevelData.swift in Sources */,
 				145F2C802BA203B400457549 /* Event.swift in Sources */,
+				460A200F2BB1E1F1002597B8 /* CollisionSystem.swift in Sources */,
 				1471B0A22BA6AA2200878B14 /* RespawnEvent.swift in Sources */,
 				46D418112BA5C88B0091A38B /* Wall.swift in Sources */,
 			);

--- a/star-dash/star-dash/Constants/GameConstants.swift
+++ b/star-dash/star-dash/Constants/GameConstants.swift
@@ -21,4 +21,12 @@ struct GameConstants {
     struct ScoreChange {
         static let pickupCollectible = 100
     }
+
+    struct DamageImpulse {
+        static let attackedByMonster = CGVector(dx: 500, dy: 0)
+    }
+
+    struct AttackImpulse {
+        static let attackedByPlayer = CGVector(dx: 0, dy: 400)
+    }
 }

--- a/star-dash/star-dash/Events/CommonEvents/JumpEvent.swift
+++ b/star-dash/star-dash/Events/CommonEvents/JumpEvent.swift
@@ -18,19 +18,4 @@ class JumpEvent: Event {
         self.entityId = entityId
         self.jumpImpulse = jumpImpulse
     }
-
-    func execute(on target: EventModifiable) {
-        guard let physicsSystem = target.system(ofType: PhysicsSystem.self) else {
-            return
-        }
-
-        guard let playerComponent = target.component(ofType: PlayerComponent.self, ofEntity: entityId),
-              playerComponent.canJump else {
-            return
-        }
-        playerComponent.canJump = false
-        playerComponent.canMove = false
-
-        physicsSystem.applyImpulse(to: entityId, impulse: jumpImpulse)
-    }
 }

--- a/star-dash/star-dash/Events/CommonEvents/MoveEvent.swift
+++ b/star-dash/star-dash/Events/CommonEvents/MoveEvent.swift
@@ -18,15 +18,4 @@ class MoveEvent: Event {
         self.entityId = entityId
         self.toLeft = toLeft
     }
-
-    func execute(on target: EventModifiable) {
-        guard let physicsComponent = target.component(ofType: PhysicsComponent.self, ofEntity: entityId),
-              let spriteComponent = target.component(ofType: SpriteComponent.self, ofEntity: entityId),
-              let textureSet = spriteComponent.textureSet else {
-            return
-        }
-
-        physicsComponent.velocity = (toLeft ? -1 : 1) * PhysicsConstants.runVelocity
-        spriteComponent.textureAtlas = textureSet.run
-    }
 }

--- a/star-dash/star-dash/Events/CommonEvents/RemoveEvent.swift
+++ b/star-dash/star-dash/Events/CommonEvents/RemoveEvent.swift
@@ -15,11 +15,4 @@ class RemoveEvent: Event {
         timestamp = Date.now
         self.entityId = entityId
     }
-
-    func execute(on target: EventModifiable) {
-        guard let entity = target.entity(with: entityId) else {
-            return
-        }
-        target.remove(entity: entity)
-    }
 }

--- a/star-dash/star-dash/Events/CommonEvents/StopMovingEvent.swift
+++ b/star-dash/star-dash/Events/CommonEvents/StopMovingEvent.swift
@@ -8,15 +8,4 @@ class StopMovingEvent: Event {
         timestamp = Date.now
         self.entityId = entityId
     }
-
-    func execute(on target: EventModifiable) {
-        guard let physicsComponent = target.component(ofType: PhysicsComponent.self, ofEntity: entityId),
-              let spriteComponent = target.component(ofType: SpriteComponent.self, ofEntity: entityId),
-              let textureSet = spriteComponent.textureSet else {
-            return
-        }
-
-        physicsComponent.velocity = .zero
-        spriteComponent.textureAtlas = nil
-    }
 }

--- a/star-dash/star-dash/Events/CommonEvents/TeleportEvent.swift
+++ b/star-dash/star-dash/Events/CommonEvents/TeleportEvent.swift
@@ -11,12 +11,4 @@ class TeleportEvent: Event {
         self.entityId = entityId
         self.destination = destination
     }
-
-    func execute(on target: EventModifiable) {
-        guard let positionSystem = target.system(ofType: PositionSystem.self) else {
-            return
-        }
-
-        positionSystem.move(entityId: entityId, to: destination)
-    }
 }

--- a/star-dash/star-dash/Events/ContactEvents/PlayerFloorContactEvent.swift
+++ b/star-dash/star-dash/Events/ContactEvents/PlayerFloorContactEvent.swift
@@ -11,15 +11,4 @@ class PlayerFloorContactEvent: Event {
         self.entityId = playerEntityId
         self.contactPoint = contactPoint
     }
-
-    func execute(on target: EventModifiable) {
-        guard let positionComponent = target.component(ofType: PositionComponent.self, ofEntity: entityId),
-              let playerComponent = target.component(ofType: PlayerComponent.self, ofEntity: entityId),
-              positionComponent.position.y > contactPoint.y else {
-            return
-        }
-
-        playerComponent.canJump = true
-        playerComponent.canMove = true
-    }
 }

--- a/star-dash/star-dash/Events/ContactEvents/PlayerMonsterContactEvent.swift
+++ b/star-dash/star-dash/Events/ContactEvents/PlayerMonsterContactEvent.swift
@@ -18,29 +18,4 @@ class PlayerMonsterContactEvent: Event {
         self.entityId = playerId
         self.monsterId = monsterId
     }
-
-    func execute(on target: EventModifiable) {
-        guard let positionSystem = target.system(ofType: PositionSystem.self),
-              let physicsSystem = target.system(ofType: PhysicsSystem.self) else {
-            return
-        }
-
-        guard let playerPosition = positionSystem.getPosition(of: entityId),
-              let monsterPosition = positionSystem.getPosition(of: monsterId) else {
-            return
-        }
-
-        guard let playerSize = physicsSystem.getSize(of: entityId),
-              let monsterSize = physicsSystem.getSize(of: monsterId) else {
-            return
-        }
-
-        let isPlayerAbove = playerPosition.y - (playerSize.height / 2) >= monsterPosition.y + (monsterSize.height / 2)
-
-        if isPlayerAbove {
-            target.add(event: PlayerAttackMonsterEvent(on: monsterId))
-        } else {
-            target.add(event: MonsterAttackPlayerEvent(from: monsterId, on: entityId))
-        }
-    }
 }

--- a/star-dash/star-dash/Events/Event.swift
+++ b/star-dash/star-dash/Events/Event.swift
@@ -10,6 +10,4 @@ import Foundation
 protocol Event {
     var timestamp: Date { get }
     var entityId: EntityId { get }
-
-    func execute(on target: EventModifiable)
 }

--- a/star-dash/star-dash/Events/EventListener.swift
+++ b/star-dash/star-dash/Events/EventListener.swift
@@ -1,0 +1,23 @@
+//
+//  EventListener.swift
+//  star-dash
+//
+//  Created by Ho Jun Hao on 25/3/24.
+//
+
+protocol EventListener: AnyObject {
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] { get set }
+
+    func handleEvent(event: Event)
+    func setUpEventHandlers()
+}
+
+extension EventListener {
+    func handleEvent(event: Event) {
+        let eventType = ObjectIdentifier(type(of: event))
+        guard let handler = eventHandlers[eventType] else {
+            return
+        }
+        handler(event)
+    }
+}

--- a/star-dash/star-dash/Events/EventListener.swift
+++ b/star-dash/star-dash/Events/EventListener.swift
@@ -9,7 +9,7 @@ protocol EventListener: AnyObject {
     var eventHandlers: [ObjectIdentifier: (Event) -> Void] { get set }
 
     func handleEvent(event: Event)
-    func setUpEventHandlers()
+    func setUp()
 }
 
 extension EventListener {

--- a/star-dash/star-dash/Events/EventManager.swift
+++ b/star-dash/star-dash/Events/EventManager.swift
@@ -12,9 +12,11 @@ typealias EventQueue = Deque<Event>
 
 class EventManager {
     private var events: EventQueue
+    private var listeners: [ObjectIdentifier: [EventListener]]
 
     init() {
-        events = EventQueue()
+        self.events = EventQueue()
+        self.listeners = [:]
     }
 
     func add(event: Event) {
@@ -23,7 +25,24 @@ class EventManager {
 
     func executeAll(on target: EventModifiable) {
         while let event = events.popFirst() {
-            event.execute(on: target)
+            emit(event: event)
+        }
+    }
+
+    func registerListener<T: Event>(for eventType: T.Type, listener: EventListener) {
+        let key = ObjectIdentifier(eventType)
+        if listeners[key] == nil {
+            listeners[key] = []
+        }
+        listeners[key]?.append(listener)
+    }
+
+    func emit(event: Event) {
+        let key = ObjectIdentifier(type(of: event))
+        if let eventListeners = listeners[key] {
+            for listener in eventListeners {
+                listener.handleEvent(event: event)
+            }
         }
     }
 }

--- a/star-dash/star-dash/Events/EventModifiable.swift
+++ b/star-dash/star-dash/Events/EventModifiable.swift
@@ -13,6 +13,7 @@ protocol EventModifiable {
     func entity(with entityId: EntityId) -> Entity?
     func system<T: System>(ofType type: T.Type) -> T?
     func add(entity: Entity)
-    func add(event: Event)
     func remove(entity: Entity)
+    func add(event: Event)
+    func registerListener<T: Event>(for eventType: T.Type, listener: EventListener)
 }

--- a/star-dash/star-dash/Events/MonsterEvents/MonsterAttackPlayerEvent.swift
+++ b/star-dash/star-dash/Events/MonsterEvents/MonsterAttackPlayerEvent.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 class MonsterAttackPlayerEvent: Event {
-    private static let damageImpulse = CGVector(dx: 500, dy: 0)
-
     let timestamp: Date
     let entityId: EntityId
     let monsterId: EntityId
@@ -18,31 +16,5 @@ class MonsterAttackPlayerEvent: Event {
         timestamp = Date.now
         self.entityId = entityId
         self.monsterId = monsterId
-    }
-
-    func execute(on target: EventModifiable) {
-        guard let healthSystem = target.system(ofType: HealthSystem.self),
-              let positionSystem = target.system(ofType: PositionSystem.self),
-              let physicsSystem = target.system(ofType: PhysicsSystem.self) else {
-            return
-        }
-
-        guard let monsterPosition = positionSystem.getPosition(of: monsterId),
-              let playerPosition = positionSystem.getPosition(of: entityId) else {
-            return
-        }
-
-        healthSystem.applyHealthChange(to: entityId, healthChange: GameConstants.HealthChange.attackedByMonster)
-
-        let isMonsterToRight = monsterPosition.x > playerPosition.x
-        let impulse = isMonsterToRight
-                      ? MonsterAttackPlayerEvent.damageImpulse * -1
-                      : MonsterAttackPlayerEvent.damageImpulse
-
-        physicsSystem.applyImpulse(to: entityId, impulse: impulse)
-
-        if !healthSystem.hasHealth(for: entityId) {
-            target.add(event: PlayerDeathEvent(on: entityId))
-        }
     }
 }

--- a/star-dash/star-dash/Events/MonsterEvents/MonsterDeathEvent.swift
+++ b/star-dash/star-dash/Events/MonsterEvents/MonsterDeathEvent.swift
@@ -15,8 +15,4 @@ class MonsterDeathEvent: Event {
         self.timestamp = Date.now
         self.entityId = entityId
     }
-
-    func execute(on target: EventModifiable) {
-        target.add(event: RemoveEvent(on: entityId))
-    }
 }

--- a/star-dash/star-dash/Events/MonsterEvents/PlayerAttackMonsterEvent.swift
+++ b/star-dash/star-dash/Events/MonsterEvents/PlayerAttackMonsterEvent.swift
@@ -8,27 +8,11 @@
 import Foundation
 
 class PlayerAttackMonsterEvent: Event {
-    private static let attackImpulse = CGVector(dx: 0, dy: 400)
-
     let timestamp: Date
     let entityId: EntityId
 
     init(on entityId: EntityId) {
         timestamp = Date.now
         self.entityId = entityId
-    }
-
-    func execute(on target: EventModifiable) {
-        guard let healthSystem = target.system(ofType: HealthSystem.self),
-              let physicSystem = target.system(ofType: PhysicsSystem.self) else {
-            return
-        }
-
-        healthSystem.applyHealthChange(to: entityId, healthChange: GameConstants.HealthChange.attackedByPlayer)
-        physicSystem.applyImpulse(to: entityId, impulse: PlayerAttackMonsterEvent.attackImpulse)
-
-        if !healthSystem.hasHealth(for: entityId) {
-            target.add(event: MonsterDeathEvent(on: entityId))
-        }
     }
 }

--- a/star-dash/star-dash/Events/PlayerEvents/PickupCollectibleEvent.swift
+++ b/star-dash/star-dash/Events/PlayerEvents/PickupCollectibleEvent.swift
@@ -18,13 +18,4 @@ class PickupCollectibleEvent: Event {
         self.entityId = entityId
         self.collectibleEntityId = collectibleEntityId
     }
-
-    func execute(on target: EventModifiable) {
-        guard let scoreSystem = target.system(ofType: ScoreSystem.self),
-              let pointsComponent = target.component(ofType: PointsComponent.self, ofEntity: collectibleEntityId) else {
-            return
-        }
-        scoreSystem.applyScoreChange(to: entityId, scoreChange: pointsComponent.points)
-        target.add(event: RemoveEvent(on: collectibleEntityId))
-    }
 }

--- a/star-dash/star-dash/Events/PlayerEvents/PlayerDeathEvent.swift
+++ b/star-dash/star-dash/Events/PlayerEvents/PlayerDeathEvent.swift
@@ -15,9 +15,4 @@ class PlayerDeathEvent: Event {
         timestamp = Date.now
         self.entityId = entityId
     }
-
-    func execute(on target: EventModifiable) {
-        // TODO: Where should player respawn to?
-        // target.add(event: RespawnEvent(on: entityId, to: ))
-    }
 }

--- a/star-dash/star-dash/Events/PlayerEvents/RespawnEvent.swift
+++ b/star-dash/star-dash/Events/PlayerEvents/RespawnEvent.swift
@@ -18,8 +18,4 @@ class RespawnEvent: Event {
         self.entityId = entityId
         self.newPosition = newPosition
     }
-
-    func execute(on target: EventModifiable) {
-        target.add(event: TeleportEvent(on: entityId, to: newPosition))
-    }
 }

--- a/star-dash/star-dash/Events/ToolEvents/UseGrappleHookEvent.swift
+++ b/star-dash/star-dash/Events/ToolEvents/UseGrappleHookEvent.swift
@@ -15,8 +15,4 @@ class UseGrappleHookEvent: Event {
         self.timestamp = Date.now
         entityId = playerEntityId
     }
-
-    func execute(on target: EventModifiable) {
-        // TODO: Shoot graple hook from player position
-    }
 }

--- a/star-dash/star-dash/GameEngine/Entities/EntityManager.swift
+++ b/star-dash/star-dash/GameEngine/Entities/EntityManager.swift
@@ -16,6 +16,7 @@ class EntityManager {
     var componentMap: ComponentMap
     var entityMap: EntityMap
     var entityComponentMap: EntityComponentMap
+
     init(componentMap: ComponentMap, entityMap: EntityMap, entityComponentMap: EntityComponentMap) {
         self.componentMap = componentMap
         self.entityMap = entityMap
@@ -58,7 +59,7 @@ class EntityManager {
     }
 
     func playerEntityId() -> EntityId? {
-        // TOODO: Add parameter to specify the player index 
+        // TODO: Add parameter to specify the player index 
         for entityId in entityMap.keys where component(ofType: PlayerComponent.self, of: entityId) != nil {
             return entityId
         }

--- a/star-dash/star-dash/GameEngine/GameEngine.swift
+++ b/star-dash/star-dash/GameEngine/GameEngine.swift
@@ -85,6 +85,12 @@ class GameEngine {
         systemManager.add(PositionSystem(entityManager, dispatcher: self))
         systemManager.add(PhysicsSystem(entityManager, dispatcher: self))
         systemManager.add(ScoreSystem(entityManager, dispatcher: self))
+        systemManager.add(HealthSystem(entityManager, dispatcher: self))
+        systemManager.add(InventorySystem(entityManager, dispatcher: self))
+        systemManager.add(AttackSystem(entityManager, dispatcher: self))
+        systemManager.add(PlayerSystem(entityManager, dispatcher: self))
+        systemManager.add(CollisionSystem(entityManager, dispatcher: self))
+        systemManager.add(MonsterSystem(entityManager, dispatcher: self))
     }
 }
 
@@ -111,6 +117,10 @@ extension GameEngine: EventModifiable {
 
     func remove(entity: Entity) {
         entityManager.remove(entity: entity)
+    }
+
+    func registerListener<T: Event>(for eventType: T.Type, listener: EventListener) {
+        eventManager.registerListener(for: eventType, listener: listener)
     }
 }
 

--- a/star-dash/star-dash/GameEngine/Systems/AttackSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/AttackSystem.swift
@@ -1,0 +1,75 @@
+//
+//  AttackSystem.swift
+//  star-dash
+//
+//  Created by Ho Jun Hao on 25/3/24.
+//
+
+import Foundation
+
+class AttackSystem: System {
+    var isActive: Bool
+    var dispatcher: EventModifiable?
+    var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
+
+    init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
+        self.isActive = true
+        self.entityManager = entityManager
+        self.dispatcher = dispatcher
+        setUpEventHandlers()
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(MonsterAttackPlayerEvent.self)] = { event in
+            if let monsterAttackPlayerEvent = event as? MonsterAttackPlayerEvent {
+                self.handleMonsterAttackPlayerEvent(event: monsterAttackPlayerEvent)
+            }
+        }
+        eventHandlers[ObjectIdentifier(PlayerAttackMonsterEvent.self)] = { event in
+            if let playerAttackMonsterEvent = event as? PlayerAttackMonsterEvent {
+                self.handlePlayerAttackMonsterEvent(event: playerAttackMonsterEvent)
+            }
+        }
+    }
+
+    private func handleMonsterAttackPlayerEvent(event: MonsterAttackPlayerEvent) {
+        guard let healthSystem = dispatcher?.system(ofType: HealthSystem.self),
+              let positionSystem = dispatcher?.system(ofType: PositionSystem.self),
+              let physicsSystem = dispatcher?.system(ofType: PhysicsSystem.self) else {
+            return
+        }
+
+        guard let monsterPosition = positionSystem.getPosition(of: event.monsterId),
+              let playerPosition = positionSystem.getPosition(of: event.entityId) else {
+            return
+        }
+
+        healthSystem.applyHealthChange(to: event.entityId, healthChange: GameConstants.HealthChange.attackedByMonster)
+
+        let isMonsterToRight = monsterPosition.x > playerPosition.x
+        let impulse = isMonsterToRight
+                      ? GameConstants.DamageImpulse.attackedByMonster * -1
+                      : GameConstants.DamageImpulse.attackedByMonster
+
+        physicsSystem.applyImpulse(to: event.entityId, impulse: impulse)
+
+        if !healthSystem.hasHealth(for: event.entityId) {
+            dispatcher?.add(event: PlayerDeathEvent(on: event.entityId))
+        }
+    }
+
+    private func handlePlayerAttackMonsterEvent(event: PlayerAttackMonsterEvent) {
+        guard let healthSystem = dispatcher?.system(ofType: HealthSystem.self),
+              let physicSystem = dispatcher?.system(ofType: PhysicsSystem.self) else {
+            return
+        }
+
+        healthSystem.applyHealthChange(to: event.entityId, healthChange: GameConstants.HealthChange.attackedByPlayer)
+        physicSystem.applyImpulse(to: event.entityId, impulse: GameConstants.AttackImpulse.attackedByPlayer)
+
+        if !healthSystem.hasHealth(for: event.entityId) {
+            dispatcher?.add(event: MonsterDeathEvent(on: event.entityId))
+        }
+    }
+}

--- a/star-dash/star-dash/GameEngine/Systems/AttackSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/AttackSystem.swift
@@ -17,10 +17,10 @@ class AttackSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: MonsterAttackPlayerEvent.self, listener: self)
         dispatcher?.registerListener(for: PlayerAttackMonsterEvent.self, listener: self)
 

--- a/star-dash/star-dash/GameEngine/Systems/AttackSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/AttackSystem.swift
@@ -21,6 +21,9 @@ class AttackSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: MonsterAttackPlayerEvent.self, listener: self)
+        dispatcher?.registerListener(for: PlayerAttackMonsterEvent.self, listener: self)
+
         eventHandlers[ObjectIdentifier(MonsterAttackPlayerEvent.self)] = { event in
             if let monsterAttackPlayerEvent = event as? MonsterAttackPlayerEvent {
                 self.handleMonsterAttackPlayerEvent(event: monsterAttackPlayerEvent)

--- a/star-dash/star-dash/GameEngine/Systems/CollisionSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/CollisionSystem.swift
@@ -17,10 +17,10 @@ class CollisionSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: RemoveEvent.self, listener: self)
         dispatcher?.registerListener(for: PlayerFloorContactEvent.self, listener: self)
         dispatcher?.registerListener(for: PlayerMonsterContactEvent.self, listener: self)

--- a/star-dash/star-dash/GameEngine/Systems/CollisionSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/CollisionSystem.swift
@@ -21,6 +21,15 @@ class CollisionSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: RemoveEvent.self, listener: self)
+        dispatcher?.registerListener(for: PlayerFloorContactEvent.self, listener: self)
+        dispatcher?.registerListener(for: PlayerMonsterContactEvent.self, listener: self)
+
+        eventHandlers[ObjectIdentifier(RemoveEvent.self)] = { event in
+            if let removeEvent = event as? RemoveEvent {
+                self.handleRemoveEvent(event: removeEvent)
+            }
+        }
         eventHandlers[ObjectIdentifier(PlayerFloorContactEvent.self)] = { event in
             if let playerFloorContactEvent = event as? PlayerFloorContactEvent {
                 self.handlePlayerFloorContactEvent(event: playerFloorContactEvent)
@@ -31,6 +40,13 @@ class CollisionSystem: System {
                 self.handlePlayerMonsterContactEvent(event: playerMonsterContactEvent)
             }
         }
+    }
+
+    private func handleRemoveEvent(event: RemoveEvent) {
+        guard let entity = dispatcher?.entity(with: event.entityId) else {
+            return
+        }
+        dispatcher?.remove(entity: entity)
     }
 
     private func handlePlayerFloorContactEvent(event: PlayerFloorContactEvent) {

--- a/star-dash/star-dash/GameEngine/Systems/CollisionSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/CollisionSystem.swift
@@ -1,0 +1,71 @@
+//
+//  CollisionSystem.swift
+//  star-dash
+//
+//  Created by Ho Jun Hao on 26/3/24.
+//
+
+import Foundation
+
+class CollisionSystem: System {
+    var isActive: Bool
+    var dispatcher: EventModifiable?
+    var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
+
+    init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
+        self.isActive = true
+        self.entityManager = entityManager
+        self.dispatcher = dispatcher
+        setUpEventHandlers()
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(PlayerFloorContactEvent.self)] = { event in
+            if let playerFloorContactEvent = event as? PlayerFloorContactEvent {
+                self.handlePlayerFloorContactEvent(event: playerFloorContactEvent)
+            }
+        }
+        eventHandlers[ObjectIdentifier(PlayerMonsterContactEvent.self)] = { event in
+            if let playerMonsterContactEvent = event as? PlayerMonsterContactEvent {
+                self.handlePlayerMonsterContactEvent(event: playerMonsterContactEvent)
+            }
+        }
+    }
+
+    private func handlePlayerFloorContactEvent(event: PlayerFloorContactEvent) {
+        guard let positionComponent = entityManager.component(ofType: PositionComponent.self, of: event.entityId),
+              let playerComponent = entityManager.component(ofType: PlayerComponent.self, of: event.entityId),
+              positionComponent.position.y > event.contactPoint.y else {
+            return
+        }
+
+        playerComponent.canJump = true
+        playerComponent.canMove = true
+    }
+
+    private func handlePlayerMonsterContactEvent(event: PlayerMonsterContactEvent) {
+        guard let positionSystem = dispatcher?.system(ofType: PositionSystem.self),
+              let physicsSystem = dispatcher?.system(ofType: PhysicsSystem.self) else {
+            return
+        }
+
+        guard let playerPosition = positionSystem.getPosition(of: event.entityId),
+              let monsterPosition = positionSystem.getPosition(of: event.monsterId) else {
+            return
+        }
+
+        guard let playerSize = physicsSystem.getSize(of: event.entityId),
+              let monsterSize = physicsSystem.getSize(of: event.monsterId) else {
+            return
+        }
+
+        let isPlayerAbove = playerPosition.y - (playerSize.height / 2) >= monsterPosition.y + (monsterSize.height / 2)
+
+        if isPlayerAbove {
+            dispatcher?.add(event: PlayerAttackMonsterEvent(on: event.monsterId))
+        } else {
+            dispatcher?.add(event: MonsterAttackPlayerEvent(from: event.monsterId, on: event.entityId))
+        }
+    }
+}

--- a/star-dash/star-dash/GameEngine/Systems/HealthSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/HealthSystem.swift
@@ -11,11 +11,13 @@ class HealthSystem: System {
     var isActive: Bool
     var dispatcher: EventModifiable?
     var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
 
     init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
+        setUpEventHandlers()
     }
 
     func hasHealth(for entityId: EntityId) -> Bool {
@@ -33,6 +35,8 @@ class HealthSystem: System {
 
         healthComponent.health += healthChange
     }
+
+    func setUpEventHandlers() {}
 
     private func getHealthComponent(of entityId: EntityId) -> HealthComponent? {
         entityManager.component(ofType: HealthComponent.self, of: entityId)

--- a/star-dash/star-dash/GameEngine/Systems/HealthSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/HealthSystem.swift
@@ -17,7 +17,7 @@ class HealthSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
     func hasHealth(for entityId: EntityId) -> Bool {
@@ -36,7 +36,7 @@ class HealthSystem: System {
         healthComponent.health += healthChange
     }
 
-    func setUpEventHandlers() {}
+    func setUp() {}
 
     private func getHealthComponent(of entityId: EntityId) -> HealthComponent? {
         entityManager.component(ofType: HealthComponent.self, of: entityId)

--- a/star-dash/star-dash/GameEngine/Systems/InventorySystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/InventorySystem.swift
@@ -17,7 +17,7 @@ class InventorySystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
     func enqueueItem(for entityId: EntityId, with powerupEntityId: EntityId) {
@@ -36,7 +36,7 @@ class InventorySystem: System {
         return inventoryComponent.inventory.removeFirst()
     }
 
-    func setUpEventHandlers() {}
+    func setUp() {}
 
     private func getInventoryComponent(of entityId: EntityId) -> InventoryComponent? {
         entityManager.component(ofType: InventoryComponent.self, of: entityId)

--- a/star-dash/star-dash/GameEngine/Systems/InventorySystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/InventorySystem.swift
@@ -11,11 +11,13 @@ class InventorySystem: System {
     var isActive: Bool
     var dispatcher: EventModifiable?
     var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
 
     init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
+        setUpEventHandlers()
     }
 
     func enqueueItem(for entityId: EntityId, with powerupEntityId: EntityId) {
@@ -33,6 +35,8 @@ class InventorySystem: System {
 
         return inventoryComponent.inventory.removeFirst()
     }
+
+    func setUpEventHandlers() {}
 
     private func getInventoryComponent(of entityId: EntityId) -> InventoryComponent? {
         entityManager.component(ofType: InventoryComponent.self, of: entityId)

--- a/star-dash/star-dash/GameEngine/Systems/MonsterSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/MonsterSystem.swift
@@ -17,10 +17,10 @@ class MonsterSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: MonsterDeathEvent.self, listener: self)
 
         eventHandlers[ObjectIdentifier(MonsterDeathEvent.self)] = { event in

--- a/star-dash/star-dash/GameEngine/Systems/MonsterSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/MonsterSystem.swift
@@ -1,0 +1,34 @@
+//
+//  MonsterSystem.swift
+//  star-dash
+//
+//  Created by Ho Jun Hao on 26/3/24.
+//
+
+import Foundation
+
+class MonsterSystem: System {
+    var isActive: Bool
+    var dispatcher: EventModifiable?
+    var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
+
+    init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
+        self.isActive = true
+        self.entityManager = entityManager
+        self.dispatcher = dispatcher
+        setUpEventHandlers()
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(MonsterDeathEvent.self)] = { event in
+            if let monsterDeathEvent = event as? MonsterDeathEvent {
+                self.handleMonsterDeathEvent(event: monsterDeathEvent)
+            }
+        }
+    }
+
+    private func handleMonsterDeathEvent(event: MonsterDeathEvent) {
+        dispatcher?.add(event: RemoveEvent(on: event.entityId))
+    }
+}

--- a/star-dash/star-dash/GameEngine/Systems/MonsterSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/MonsterSystem.swift
@@ -21,6 +21,8 @@ class MonsterSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: MonsterDeathEvent.self, listener: self)
+
         eventHandlers[ObjectIdentifier(MonsterDeathEvent.self)] = { event in
             if let monsterDeathEvent = event as? MonsterDeathEvent {
                 self.handleMonsterDeathEvent(event: monsterDeathEvent)

--- a/star-dash/star-dash/GameEngine/Systems/PhysicsSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PhysicsSystem.swift
@@ -65,6 +65,10 @@ class PhysicsSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: MoveEvent.self, listener: self)
+        dispatcher?.registerListener(for: JumpEvent.self, listener: self)
+        dispatcher?.registerListener(for: StopMovingEvent.self, listener: self)
+
         eventHandlers[ObjectIdentifier(MoveEvent.self)] = { event in
             if let moveEvent = event as? MoveEvent {
                 self.handleMoveEvent(event: moveEvent)

--- a/star-dash/star-dash/GameEngine/Systems/PhysicsSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PhysicsSystem.swift
@@ -17,7 +17,7 @@ class PhysicsSystem: System {
         self.isActive = true
         self.dispatcher = dispatcher
         self.entityManager = entityManager
-        setUpEventHandlers()
+        setUp()
     }
 
     func update(by deltaTime: TimeInterval) {
@@ -64,7 +64,7 @@ class PhysicsSystem: System {
         return physicsComponent.size
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: MoveEvent.self, listener: self)
         dispatcher?.registerListener(for: JumpEvent.self, listener: self)
         dispatcher?.registerListener(for: StopMovingEvent.self, listener: self)

--- a/star-dash/star-dash/GameEngine/Systems/PhysicsSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PhysicsSystem.swift
@@ -11,11 +11,13 @@ class PhysicsSystem: System {
     var isActive: Bool
     var dispatcher: EventModifiable?
     var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
 
     init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
         self.isActive = true
         self.dispatcher = dispatcher
         self.entityManager = entityManager
+        setUpEventHandlers()
     }
 
     func update(by deltaTime: TimeInterval) {
@@ -60,6 +62,56 @@ class PhysicsSystem: System {
         }
 
         return physicsComponent.size
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(MoveEvent.self)] = { event in
+            if let moveEvent = event as? MoveEvent {
+                self.handleMoveEvent(event: moveEvent)
+            }
+        }
+        eventHandlers[ObjectIdentifier(JumpEvent.self)] = { event in
+            if let jumpEvent = event as? JumpEvent {
+                self.handleJumpEvent(event: jumpEvent)
+            }
+        }
+        eventHandlers[ObjectIdentifier(StopMovingEvent.self)] = { event in
+            if let stopMovingEvent = event as? StopMovingEvent {
+                self.handleStopMovingEvent(event: stopMovingEvent)
+            }
+        }
+    }
+
+    private func handleMoveEvent(event: MoveEvent) {
+        guard let physicsComponent = getPhysicsComponent(of: event.entityId),
+              let spriteComponent = entityManager.component(ofType: SpriteComponent.self, of: event.entityId),
+              let textureSet = spriteComponent.textureSet else {
+            return
+        }
+
+        physicsComponent.velocity = (event.toLeft ? -1 : 1) * PhysicsConstants.runVelocity
+        spriteComponent.textureAtlas = textureSet.run
+    }
+
+    private func handleJumpEvent(event: JumpEvent) {
+        guard let playerComponent = entityManager.component(ofType: PlayerComponent.self, of: event.entityId),
+              playerComponent.canJump else {
+            return
+        }
+        playerComponent.canJump = false
+        playerComponent.canMove = false
+
+        applyImpulse(to: event.entityId, impulse: event.jumpImpulse)
+    }
+
+    private func handleStopMovingEvent(event: StopMovingEvent) {
+        guard let physicsComponent = getPhysicsComponent(of: event.entityId),
+              let spriteComponent = entityManager.component(ofType: SpriteComponent.self, of: event.entityId) else {
+            return
+        }
+
+        physicsComponent.velocity = .zero
+        spriteComponent.textureAtlas = nil
     }
 
     private func getPhysicsComponent(of entityId: EntityId) -> PhysicsComponent? {

--- a/star-dash/star-dash/GameEngine/Systems/PlayerSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PlayerSystem.swift
@@ -21,6 +21,9 @@ class PlayerSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: RespawnEvent.self, listener: self)
+        dispatcher?.registerListener(for: PlayerDeathEvent.self, listener: self)
+
         eventHandlers[ObjectIdentifier(RespawnEvent.self)] = { event in
             if let respawanEvent = event as? RespawnEvent {
                 self.handleRespawnEvent(event: respawanEvent)

--- a/star-dash/star-dash/GameEngine/Systems/PlayerSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PlayerSystem.swift
@@ -17,10 +17,10 @@ class PlayerSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: RespawnEvent.self, listener: self)
         dispatcher?.registerListener(for: PlayerDeathEvent.self, listener: self)
 

--- a/star-dash/star-dash/GameEngine/Systems/PlayerSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PlayerSystem.swift
@@ -1,0 +1,43 @@
+//
+//  PlayerSystem.swift
+//  star-dash
+//
+//  Created by Ho Jun Hao on 26/3/24.
+//
+
+import Foundation
+
+class PlayerSystem: System {
+    var isActive: Bool
+    var dispatcher: EventModifiable?
+    var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
+
+    init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
+        self.isActive = true
+        self.entityManager = entityManager
+        self.dispatcher = dispatcher
+        setUpEventHandlers()
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(RespawnEvent.self)] = { event in
+            if let respawanEvent = event as? RespawnEvent {
+                self.handleRespawnEvent(event: respawanEvent)
+            }
+        }
+        eventHandlers[ObjectIdentifier(PlayerDeathEvent.self)] = { event in
+            if let playerDeathEvent = event as? PlayerDeathEvent {
+                self.handlePlayerDeathEvent(event: playerDeathEvent)
+            }
+        }
+    }
+
+    private func handleRespawnEvent(event: RespawnEvent) {
+        dispatcher?.add(event: TeleportEvent(on: event.entityId, to: event.newPosition))
+    }
+
+    private func handlePlayerDeathEvent(event: PlayerDeathEvent) {
+        // TODO
+    }
+}

--- a/star-dash/star-dash/GameEngine/Systems/PositionSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PositionSystem.swift
@@ -17,7 +17,7 @@ class PositionSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
     func move(entityId: EntityId, to newPosition: CGPoint) {
@@ -44,7 +44,7 @@ class PositionSystem: System {
         return positionComponent.position
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: TeleportEvent.self, listener: self)
 
         eventHandlers[ObjectIdentifier(TeleportEvent.self)] = { event in

--- a/star-dash/star-dash/GameEngine/Systems/PositionSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PositionSystem.swift
@@ -45,6 +45,8 @@ class PositionSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: TeleportEvent.self, listener: self)
+
         eventHandlers[ObjectIdentifier(TeleportEvent.self)] = { event in
             if let teleportEvent = event as? TeleportEvent {
                 self.handleTeleportEvent(event: teleportEvent)

--- a/star-dash/star-dash/GameEngine/Systems/PositionSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/PositionSystem.swift
@@ -11,11 +11,13 @@ class PositionSystem: System {
     var isActive: Bool
     var dispatcher: EventModifiable?
     var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
 
     init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
+        setUpEventHandlers()
     }
 
     func move(entityId: EntityId, to newPosition: CGPoint) {
@@ -40,6 +42,18 @@ class PositionSystem: System {
         }
 
         return positionComponent.position
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(TeleportEvent.self)] = { event in
+            if let teleportEvent = event as? TeleportEvent {
+                self.handleTeleportEvent(event: teleportEvent)
+            }
+        }
+    }
+
+    private func handleTeleportEvent(event: TeleportEvent) {
+        move(entityId: event.entityId, to: event.destination)
     }
 
     private func getPositionComponent(of entityId: EntityId) -> PositionComponent? {

--- a/star-dash/star-dash/GameEngine/Systems/ScoreSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/ScoreSystem.swift
@@ -17,7 +17,7 @@ class ScoreSystem: System {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
-        setUpEventHandlers()
+        setUp()
     }
 
     func score(of entityId: EntityId) -> Int? {
@@ -36,7 +36,7 @@ class ScoreSystem: System {
         scoreComponent.score += scoreChange
     }
 
-    func setUpEventHandlers() {
+    func setUp() {
         dispatcher?.registerListener(for: PickupCollectibleEvent.self, listener: self)
 
         eventHandlers[ObjectIdentifier(PickupCollectibleEvent.self)] = { event in

--- a/star-dash/star-dash/GameEngine/Systems/ScoreSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/ScoreSystem.swift
@@ -37,6 +37,8 @@ class ScoreSystem: System {
     }
 
     func setUpEventHandlers() {
+        dispatcher?.registerListener(for: PickupCollectibleEvent.self, listener: self)
+
         eventHandlers[ObjectIdentifier(PickupCollectibleEvent.self)] = { event in
             if let pickupCollectibleEvent = event as? PickupCollectibleEvent {
                 self.handlePickupCollectibleEvent(event: pickupCollectibleEvent)

--- a/star-dash/star-dash/GameEngine/Systems/ScoreSystem.swift
+++ b/star-dash/star-dash/GameEngine/Systems/ScoreSystem.swift
@@ -11,11 +11,13 @@ class ScoreSystem: System {
     var isActive: Bool
     var dispatcher: EventModifiable?
     var entityManager: EntityManager
+    var eventHandlers: [ObjectIdentifier: (Event) -> Void] = [:]
 
     init(_ entityManager: EntityManager, dispatcher: EventModifiable? = nil) {
         self.isActive = true
         self.entityManager = entityManager
         self.dispatcher = dispatcher
+        setUpEventHandlers()
     }
 
     func score(of entityId: EntityId) -> Int? {
@@ -32,6 +34,24 @@ class ScoreSystem: System {
         }
 
         scoreComponent.score += scoreChange
+    }
+
+    func setUpEventHandlers() {
+        eventHandlers[ObjectIdentifier(PickupCollectibleEvent.self)] = { event in
+            if let pickupCollectibleEvent = event as? PickupCollectibleEvent {
+                self.handlePickupCollectibleEvent(event: pickupCollectibleEvent)
+            }
+        }
+    }
+
+    private func handlePickupCollectibleEvent(event: PickupCollectibleEvent) {
+        guard let pointsComponent = entityManager.component(ofType: PointsComponent.self,
+                                                            of: event.collectibleEntityId) else {
+            return
+        }
+
+        applyScoreChange(to: event.entityId, scoreChange: pointsComponent.points)
+        dispatcher?.add(event: RemoveEvent(on: event.collectibleEntityId))
     }
 
     private func getScoreComponent(of entityId: EntityId) -> ScoreComponent? {

--- a/star-dash/star-dash/GameEngine/Systems/System.swift
+++ b/star-dash/star-dash/GameEngine/Systems/System.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol System {
+protocol System: EventListener {
     var isActive: Bool { get set }
     var dispatcher: EventModifiable? { get set }
     var entityManager: EntityManager { get set }


### PR DESCRIPTION
Resolves #26

# Changes

- Create Publisher-Subscriber pattern between EventManager and Systems (EventListener)
- Each System now inherits an EventListener protocol
  - has a variable called eventHandlers
  - `setUp()` which registers the system into the event manager and creates the map
- Event Manager emits the corresponding events to the Systems (EventListeners) that subscribe to the event
- handleEvent is not found in each system as there is a default extension for it.


# Unresolved issues
- Death checks are still done manually in the system (not in the system.update cycle)
- In general I just copied over the events into system. Much more simplification can be done.




