### PR TITLE
fix grappling length calculation bug

### DIFF
--- a/star-dash/star-dash/Constants/GameConstants.swift
+++ b/star-dash/star-dash/Constants/GameConstants.swift
@@ -35,7 +35,6 @@ struct GameConstants {
         static let deltaPositionVectorRight = CGVector(dx: 10, dy: 10)
         static let deltaPositionVectorLeft = CGVector(dx: -10, dy: 10)
         static let deltaAngle: Double = 3
-        static let minLength: Double = 280
         static let maxLength: Double = 900
         static let defaultRetractLength: Double = 140
         static let defaultSwingAngle: Double = 120

--- a/star-dash/star-dash/GameEngine/Entities/EntityManager.swift
+++ b/star-dash/star-dash/GameEngine/Entities/EntityManager.swift
@@ -73,7 +73,7 @@ class EntityManager: EntityManagerInterface {
 
     func remove(component: Component) {
         componentMap[component.id] = nil
-        entityComponentMap[component.entityId]?.remove(component.id)
+        entityComponentMap[component.entityId]?[ObjectIdentifier(type(of: component))] = nil
     }
 
     func entity(with entityId: EntityId) -> Entity? {

--- a/star-dash/star-dash/GameEngine/Systems/Complex/Movement/GrappleHookModule.swift
+++ b/star-dash/star-dash/GameEngine/Systems/Complex/Movement/GrappleHookModule.swift
@@ -249,21 +249,34 @@ class GrappleHookModule: MovementModule {
         }
 
         setSwingAngle(for: event.grappleHookId)
+        setRetractLength(for: event.grappleHookId)
 
         guard hookState == .shooting else {
             return nil
         }
 
-        if length(of: event.grappleHookId) >= GameConstants.Hook.minLength {
-            setHookState(of: event.grappleHookId, to: .retracting)
-        } else {
-            dispatcher?.add(event: ReleaseGrappleHookEvent(using: event.grappleHookId))
-        }
+        setHookState(of: event.grappleHookId, to: .retracting)
+
         return nil
     }
 }
 
 extension GrappleHookModule {
+    private func setRetractLength(for hookEntityId: EntityId) {
+        guard let hookPosition = getEndPoint(of: hookEntityId),
+              let currPosition = getStartPoint(of: hookEntityId),
+              let hookComponent = getHookComponent(of: hookEntityId) else {
+            return
+        }
+
+        let dx = hookPosition.x - currPosition.x
+        let dy = hookPosition.y - currPosition.y
+        let distance = hypot(dx, dy)
+        let angle = atan2(dy, dx)
+        let retractLength = distance - sin(angle) * distance
+        hookComponent.lengthToRetract = retractLength * 1.5
+    }
+
     private func setSwingAngle(for hookEntityId: EntityId) {
         guard let hookPosition = getEndPoint(of: hookEntityId),
               let currPosition = getStartPoint(of: hookEntityId),


### PR DESCRIPTION
In the previous implementation, I overlooked the fact that how much the grappling hook has to retract depends on how far the hook has extended. I erroneously assumed that once the hook extended beyond a minimum length based on the player's height, it could be retracted. However, I have now corrected this approach by calculating the precise retraction length using trigonometry.