### PR TITLE
Bug/gesture bounds

### DIFF
--- a/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
@@ -21,6 +21,7 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
         setupActionControls()
         setupGestureRecognizers()
     }
+    var rotatedBy: CGFloat = 0
 
     // MARK: Private methods for setup
 
@@ -117,8 +118,15 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
     // To ensure gesture recognise only in a specific area
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         let touchLocation = touch.location(in: self)
-        let halfScreenWidth = self.frame.width / 2
-        let ignoredAreaRect = CGRect(x: halfScreenWidth, y: 0, width: .infinity, height: self.frame.height)
+        var frameWidth = self.frame.width
+        var frameHeight = self.frame.height
+        
+        if rotatedBy == .pi / 2 || rotatedBy == .pi * 3 / 2 {
+            frameWidth = self.frame.height
+            frameHeight = self.frame.width
+        }
+        let halfScreenWidth = frameWidth / 2
+        let ignoredAreaRect = CGRect(x: halfScreenWidth, y: 0, width: frameWidth, height: frameHeight)
         if ignoredAreaRect.contains(touchLocation) {
             return false
         }
@@ -164,8 +172,10 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
             if shouldSendMoveEvent(location: touchPoint) {
                 let isLeft = gesture.location(in: joystickView).x < joystickView.bounds.midX
                 controlViewDelegate?.joystickMoved(toLeft: isLeft, from: self)
+                joystickView.moveJoystick(location: gesture.location(in: joystickView))
+
             }
-            }
+        }
     }
 
     private func stopLongPressTimer() {

--- a/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
@@ -16,12 +16,14 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
     var controlViewDelegate: ControlViewDelegate?
     var jumpButton: UIButton?
     var hookButton: UIButton?
+    var rotatedBy: CGFloat = 0
+    
+ 
     func setupSubviews() {
         setupMovementControls()
         setupActionControls()
         setupGestureRecognizers()
     }
-    var rotatedBy: CGFloat = 0
 
     // MARK: Private methods for setup
 

--- a/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
@@ -17,8 +17,7 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
     var jumpButton: UIButton?
     var hookButton: UIButton?
     var rotatedBy: CGFloat = 0
-    
- 
+
     func setupSubviews() {
         setupMovementControls()
         setupActionControls()

--- a/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
@@ -141,7 +141,7 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
             break
         }
     }
-    
+
     private func touchInActionButton(touchPoint: CGPoint) -> Bool {
         guard let jumpButton = jumpButton,
               let hookButton = hookButton else {
@@ -151,21 +151,21 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
     }
 
     private func startLongPressTimer(_ gesture: UILongPressGestureRecognizer) {
-            
+
             longPressTimer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { [weak self] _ in
             let touchPoint = gesture.location(in: self)
-        
+
             guard let self = self,
                 let joystickView = self.joystickView,
                   !touchInActionButton(touchPoint: touchPoint) else {
                 return
             }
-            
+
             if shouldSendMoveEvent(location: touchPoint) {
                 let isLeft = gesture.location(in: joystickView).x < joystickView.bounds.midX
                 controlViewDelegate?.joystickMoved(toLeft: isLeft, from: self)
             }
-        }
+            }
     }
 
     private func stopLongPressTimer() {

--- a/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/ControlView.swift
@@ -120,7 +120,7 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
         let touchLocation = touch.location(in: self)
         var frameWidth = self.frame.width
         var frameHeight = self.frame.height
-        
+
         if rotatedBy == .pi / 2 || rotatedBy == .pi * 3 / 2 {
             frameWidth = self.frame.height
             frameHeight = self.frame.width
@@ -175,7 +175,7 @@ class ControlView: UIView, UIGestureRecognizerDelegate {
                 joystickView.moveJoystick(location: gesture.location(in: joystickView))
 
             }
-        }
+            }
     }
 
     private func stopLongPressTimer() {

--- a/star-dash/star-dash/Rendering/PlayerView/PlayerView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/PlayerView.swift
@@ -35,6 +35,7 @@ class PlayerView {
         superview.addSubview(self.minimapView)
 
         self.controlView = ControlView(frame: superview.bounds, rotatedBy: rotation)
+        controlView.rotatedBy = rotation
         superview.addSubview(self.controlView)
     }
 

--- a/star-dash/star-dash/Rendering/PlayerView/PlayerView.swift
+++ b/star-dash/star-dash/Rendering/PlayerView/PlayerView.swift
@@ -35,7 +35,7 @@ class PlayerView {
         superview.addSubview(self.minimapView)
 
         self.controlView = ControlView(frame: superview.bounds, rotatedBy: rotation)
-        controlView.rotatedBy = rotation
+        self.controlView.rotatedBy = rotation
         superview.addSubview(self.controlView)
     }
 


### PR DESCRIPTION
Previously, holding down jump button will trigger move forward. Long pressing on right edge of screen will trigger move forward

Fix gesture control to check if long presses are in any action buttons,

fix issue where the ignore area rect on local multiplayer is smaller than expected, I think this is because the frame size is not inverted when the rotation is 90.

fix issue where long press gesture on some areas of screen don't move joystick

closes #137 
 
 